### PR TITLE
Ensure template theme name stays consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.gradle/
+.kotlinc/
+.kotlin/
+**/build/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/app/src/main/java/com/example/androidapper/creator/AppTemplateGenerator.kt
+++ b/app/src/main/java/com/example/androidapper/creator/AppTemplateGenerator.kt
@@ -1,0 +1,126 @@
+package com.example.androidapper.creator
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Locale
+
+/**
+ * Generates the minimal set of files required for a freshly scaffolded Android
+ * application.
+ */
+public class AppTemplateGenerator(
+    private val fileWriter: FileWriter = FileWriter(),
+) {
+
+    /**
+     * Holds metadata about the generated files for convenient assertions in tests.
+     */
+    public data class GenerationResult(
+        val manifestPath: Path,
+        val themePath: Path,
+        val themeName: String,
+    )
+
+    /**
+     * Generates the manifest and theme resources for the provided [appName].
+     *
+     * The method derives the theme name once and reuses it across all
+     * generated artifacts.
+     */
+    public fun generate(appName: String, outputDir: Path): GenerationResult {
+        val sanitizedThemeName: String = sanitizeThemeName(appName)
+        val manifestContent: String = buildAndroidManifest(appName, sanitizedThemeName)
+        val themeContent: String = generatedTheme(sanitizedThemeName)
+
+        val manifestPath: Path = outputDir.resolve("src/main/AndroidManifest.xml")
+        val themePath: Path = outputDir.resolve("src/main/res/values/themes.xml")
+
+        fileWriter.write(manifestPath, manifestContent)
+        fileWriter.write(themePath, themeContent)
+
+        return GenerationResult(
+            manifestPath = manifestPath,
+            themePath = themePath,
+            themeName = sanitizedThemeName,
+        )
+    }
+
+    /**
+     * Builds the Android manifest XML for the provided [appName] using the
+     * supplied [sanitizedThemeName].
+     */
+    public fun buildAndroidManifest(appName: String, sanitizedThemeName: String): String {
+        return """
+            |<?xml version="1.0" encoding="utf-8"?>
+            |<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+            |    <application
+            |        android:label="$appName"
+            |        android:theme="@style/$sanitizedThemeName">
+            |        <activity android:name=".MainActivity">
+            |            <intent-filter>
+            |                <action android:name="android.intent.action.MAIN" />
+            |                <category android:name="android.intent.category.LAUNCHER" />
+            |            </intent-filter>
+            |        </activity>
+            |    </application>
+            |</manifest>
+        """.trimMargin()
+    }
+
+    /**
+     * Builds the Android manifest XML and automatically derives the theme name.
+     */
+    public fun buildAndroidManifest(appName: String): String {
+        val sanitizedThemeName: String = sanitizeThemeName(appName)
+        return buildAndroidManifest(appName, sanitizedThemeName)
+    }
+
+    /**
+     * Generates the primary theme XML for the provided [sanitizedThemeName].
+     */
+    public fun generatedTheme(sanitizedThemeName: String): String {
+        return """
+            |<resources>
+            |    <style name="$sanitizedThemeName" parent="Theme.Material3.DayNight.NoActionBar">
+            |        <item name="android:statusBarColor">@android:color/transparent</item>
+            |        <item name="android:navigationBarColor">@android:color/transparent</item>
+            |    </style>
+            |</resources>
+        """.trimMargin()
+    }
+
+    /**
+     * Sanitises the theme name by stripping non-alphanumeric characters and
+     * converting the result to upper camel case.
+     */
+    public fun sanitizeThemeName(appName: String): String {
+        val parts: List<String> = appName
+            .split("[^A-Za-z0-9]+".toRegex())
+            .filter { part -> part.isNotBlank() }
+            .map { part ->
+                val lowerCased: String = part.lowercase(Locale.US)
+                lowerCased.replaceFirstChar { character ->
+                    if (character.isLowerCase()) character.titlecase(Locale.US) else character.toString()
+                }
+            }
+
+        val condensed: String = parts.joinToString(separator = "")
+        val baseName: String = if (condensed.isEmpty()) "App" else condensed
+        val prefixAdjusted: String = if (baseName.startsWith("Theme")) baseName else "Theme$baseName"
+        return prefixAdjusted
+    }
+
+    /**
+     * Simple file writer helper that always writes UTF-8 encoded content.
+     */
+    public class FileWriter {
+        public fun write(path: Path, content: String): Unit {
+            val parent: Path? = path.parent
+            if (parent != null) {
+                Files.createDirectories(parent)
+            }
+            Files.writeString(path, content, StandardCharsets.UTF_8)
+        }
+    }
+}

--- a/app/src/test/java/com/example/androidapper/creator/AppTemplateGeneratorTest.kt
+++ b/app/src/test/java/com/example/androidapper/creator/AppTemplateGeneratorTest.kt
@@ -1,0 +1,53 @@
+package com.example.androidapper.creator
+
+import java.io.InputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.inputStream
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppTemplateGeneratorTest {
+
+    @Test
+    fun `generator reuses sanitized theme across manifest and theme resources`() {
+        val generator: AppTemplateGenerator = AppTemplateGenerator()
+        val tempDir = createTempDirectory(prefix = "android-apper-")
+
+        try {
+            val result: AppTemplateGenerator.GenerationResult = generator.generate(
+                appName = "My Fancy App!",
+                outputDir = tempDir,
+            )
+
+            val manifestContent: String = result.manifestPath.readText()
+            val themeContent: String = result.themePath.readText()
+            val documentBuilderFactory: DocumentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
+                isNamespaceAware = true
+            }
+            val manifestThemeName: String = result.manifestPath.inputStream().use { input: InputStream ->
+                val document = documentBuilderFactory.newDocumentBuilder().parse(input)
+                val applicationNode = document.getElementsByTagName("application").item(0)
+                val themeAttribute: String = (applicationNode?.attributes?.getNamedItemNS(
+                    "http://schemas.android.com/apk/res/android",
+                    "theme",
+                )?.nodeValue) ?: error("Manifest did not expose a theme: \n$manifestContent")
+                themeAttribute.substringAfterLast('/')
+            }
+
+            assertEquals(expected = result.themeName, actual = manifestThemeName)
+            assertTrue(actual = themeContent.contains("<style name=\"${result.themeName}\""))
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `sanitize theme name produces predictable camel case`() {
+        val generator: AppTemplateGenerator = AppTemplateGenerator()
+        val sanitized: String = generator.sanitizeThemeName("hello world!!")
+        assertEquals(expected = "ThemeHelloWorld", actual = sanitized)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm") version "2.0.21" apply false
+}
+
+subprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "Android-Apper"
+include("app")


### PR DESCRIPTION
## Summary
- derive a sanitized theme name once and reuse it when rendering the Android manifest and theme XML
- ensure the template generator writes the updated theme resource using that name and add the supporting Gradle project scaffolding
- add a regression test that parses the generated manifest and verifies the referenced style exists in themes.xml

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8711b942083289ac5e5b30a106a6a